### PR TITLE
Fix heap plugin object selection

### DIFF
--- a/Alpha/Plugins/Global/Sources/ALPHAInstanceSource.m
+++ b/Alpha/Plugins/Global/Sources/ALPHAInstanceSource.m
@@ -99,6 +99,9 @@ NSString* const ALPHAInstanceDataClassNameIdentifier = @"kALPHAInstanceDataClass
         }
         
         item.title = title;
+        if ([instanceData[@"instances"] isEqual:instance]) {
+            item.cellParameters = @{@"backgroundColor":[UIColor redColor]};
+        }
         item.detail = [ALPHARuntimeUtility descriptionForIvarOrPropertyValue:instance];
         
         row++;

--- a/Alpha/Plugins/Global/Sources/ALPHAInstanceSource.m
+++ b/Alpha/Plugins/Global/Sources/ALPHAInstanceSource.m
@@ -82,8 +82,9 @@ NSString* const ALPHAInstanceDataClassNameIdentifier = @"kALPHAInstanceDataClass
     
     for (id instance in instanceData[@"instances"])
     {
+        
         ALPHAScreenItem* item = [[ALPHAScreenItem alloc] init];
-        item.object = instance;
+        item.object = [ALPHARequest requestForObject:instance];
         
         NSString *title = nil;
         


### PR DESCRIPTION
Heap plugin items was not selectable. Fixed crash for arrays which contains self reference (as well as other objc collection types `NSDictionary`, `NSSet`, `NSOrderedSet`, `NSHashTable`, `NSMapTable`, `NSPointerArray`).
